### PR TITLE
titre du site : Mathilde Saliou

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,1 +1,2 @@
 remote_theme: scribouilli/mimoza
+title : Mathilde Saliou

--- a/_config.yml
+++ b/_config.yml
@@ -1,2 +1,2 @@
 remote_theme: scribouilli/mimoza
-title : Mathilde Saliou
+title : "Mathilde Saliou"


### PR DESCRIPTION
Actuellement, le titre est celui par défaut, et donc sera ```mathildesaliou```
Cette proposition de modification changera le titre en ```Mathilde Saliou```